### PR TITLE
Set up format lint and typecheck configuration

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json"
+}

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ zinfer src/schemas.ts --unify-same --suffix Schema
 ### ライブラリ API
 
 ```typescript
-import { extractZodTypes, extractAllSchemas } from 'zinfer';
+import { extractZodTypes, extractAllSchemas } from "zinfer";
 
 // 単一スキーマの抽出
-const { input, output } = extractZodTypes('./schemas.ts', 'UserSchema');
-console.log(input);  // { id: string; name: string; }
+const { input, output } = extractZodTypes("./schemas.ts", "UserSchema");
+console.log(input); // { id: string; name: string; }
 console.log(output); // { id: string; name: string; }
 
 // ファイル内の全スキーマを抽出
-const results = extractAllSchemas('./schemas.ts');
+const results = extractAllSchemas("./schemas.ts");
 for (const result of results) {
   console.log(`${result.schemaName}: ${result.input}`);
 }
@@ -87,37 +87,37 @@ Options:
 ### zinfer.config.ts
 
 ```typescript
-import { defineConfig } from 'zinfer';
+import { defineConfig } from "zinfer";
 
 export default defineConfig({
   // 処理対象ファイル
-  include: ['src/**/*.schema.ts'],
+  include: ["src/**/*.schema.ts"],
 
   // 除外パターン
-  exclude: ['**/*.test.ts'],
+  exclude: ["**/*.test.ts"],
 
   // tsconfig.json のパス
-  project: './tsconfig.json',
+  project: "./tsconfig.json",
 
   // 抽出するスキーマ名（指定しない場合は全て）
-  schemas: ['UserSchema', 'PostSchema'],
+  schemas: ["UserSchema", "PostSchema"],
 
   // 出力オプション
-  outDir: './types',
-  outFile: './types/index.ts',
-  outPattern: '[name].types.ts',
+  outDir: "./types",
+  outFile: "./types/index.ts",
+  outPattern: "[name].types.ts",
   declaration: true,
 
   // 型名オプション
-  suffix: 'Schema',           // スキーマ名から削除するサフィックス
-  inputSuffix: 'Input',       // input 型のサフィックス
-  outputSuffix: 'Output',     // output 型のサフィックス
-  unifySame: true,            // input === output なら1つの型に
+  suffix: "Schema", // スキーマ名から削除するサフィックス
+  inputSuffix: "Input", // input 型のサフィックス
+  outputSuffix: "Output", // output 型のサフィックス
+  unifySame: true, // input === output なら1つの型に
 
   // カスタムマッピング
   map: {
-    'UserSchema': 'User',
-    'PostSchema': 'Article',
+    UserSchema: "User",
+    PostSchema: "Article",
   },
 
   // .describe() を TSDoc として出力
@@ -139,6 +139,7 @@ export default defineConfig({
 ```
 
 設定ファイルの検索順序:
+
 1. `zinfer.config.ts`
 2. `zinfer.config.mts`
 3. `zinfer.config.js`
@@ -152,6 +153,7 @@ CLI オプションは設定ファイルより優先されます。
 ### 基本的な出力
 
 入力スキーマ:
+
 ```typescript
 export const UserSchema = z.object({
   id: z.string().uuid(),
@@ -161,6 +163,7 @@ export const UserSchema = z.object({
 ```
 
 出力 (デフォルト):
+
 ```typescript
 export type UserSchemaInput = {
   id: string;
@@ -176,6 +179,7 @@ export type UserSchemaOutput = {
 ```
 
 出力 (`--unify-same --suffix Schema`):
+
 ```typescript
 export type User = {
   id: string;
@@ -187,6 +191,7 @@ export type User = {
 ### Transform がある場合
 
 入力スキーマ:
+
 ```typescript
 export const DateSchema = z.object({
   createdAt: z.string().transform((s) => new Date(s)),
@@ -195,6 +200,7 @@ export const DateSchema = z.object({
 ```
 
 出力:
+
 ```typescript
 export type DateSchemaInput = {
   createdAt: string;
@@ -210,15 +216,19 @@ export type DateSchemaOutput = {
 ### TSDoc コメント付き (`--with-descriptions`)
 
 入力スキーマ:
+
 ```typescript
-export const UserSchema = z.object({
-  id: z.string().uuid().describe('Unique user identifier'),
-  name: z.string().describe("User's display name"),
-  email: z.string().email().describe('Email address'),
-}).describe('User account information');
+export const UserSchema = z
+  .object({
+    id: z.string().uuid().describe("Unique user identifier"),
+    name: z.string().describe("User's display name"),
+    email: z.string().email().describe("Email address"),
+  })
+  .describe("User account information");
 ```
 
 出力:
+
 ```typescript
 /**
  * User account information
@@ -272,7 +282,7 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
     z.null(),
     z.array(JsonValueSchema),
     z.record(JsonValueSchema),
-  ])
+  ]),
 );
 ```
 
@@ -285,12 +295,12 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 単一スキーマから型を抽出します。
 
 ```typescript
-import { extractZodTypes } from 'zinfer';
+import { extractZodTypes } from "zinfer";
 
 const { input, output } = extractZodTypes(
-  './schemas.ts',
-  'UserSchema',
-  './tsconfig.json'  // optional
+  "./schemas.ts",
+  "UserSchema",
+  "./tsconfig.json", // optional
 );
 ```
 
@@ -299,9 +309,9 @@ const { input, output } = extractZodTypes(
 ファイル内の全スキーマを抽出します。
 
 ```typescript
-import { extractAllSchemas } from 'zinfer';
+import { extractAllSchemas } from "zinfer";
 
-const results = extractAllSchemas('./schemas.ts');
+const results = extractAllSchemas("./schemas.ts");
 // results: ExtractResult[]
 ```
 
@@ -310,14 +320,14 @@ const results = extractAllSchemas('./schemas.ts');
 抽出結果から TypeScript 型宣言を生成します。
 
 ```typescript
-import { extractAllSchemas, generateTypeDeclarations } from 'zinfer';
+import { extractAllSchemas, generateTypeDeclarations } from "zinfer";
 
-const results = extractAllSchemas('./schemas.ts');
+const results = extractAllSchemas("./schemas.ts");
 const declarations = generateTypeDeclarations(results, {
   nameMapping: {
-    removeSuffix: 'Schema',
-    inputSuffix: 'Input',
-    outputSuffix: 'Output',
+    removeSuffix: "Schema",
+    inputSuffix: "Input",
+    outputSuffix: "Output",
   },
   declaration: {
     unifySame: true,
@@ -332,27 +342,24 @@ console.log(declarations);
 より細かい制御が必要な場合:
 
 ```typescript
-import { ZodTypeExtractor } from 'zinfer';
+import { ZodTypeExtractor } from "zinfer";
 
-const extractor = new ZodTypeExtractor('./tsconfig.json');
+const extractor = new ZodTypeExtractor("./tsconfig.json");
 
 // 単一スキーマ
 const result = extractor.extract({
-  filePath: './schemas.ts',
-  schemaName: 'UserSchema',
+  filePath: "./schemas.ts",
+  schemaName: "UserSchema",
 });
 
 // 全スキーマ
-const allResults = extractor.extractAll('./schemas.ts');
+const allResults = extractor.extractAll("./schemas.ts");
 
 // 複数スキーマを指定
-const selectedResults = extractor.extractMultiple(
-  './schemas.ts',
-  ['UserSchema', 'PostSchema']
-);
+const selectedResults = extractor.extractMultiple("./schemas.ts", ["UserSchema", "PostSchema"]);
 
 // スキーマ名の一覧
-const schemaNames = extractor.getSchemaNames('./schemas.ts');
+const schemaNames = extractor.getSchemaNames("./schemas.ts");
 ```
 
 ## 対応している Zod 機能

--- a/oxlint.json
+++ b/oxlint.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["dist", "node_modules", "coverage"]
+}

--- a/package.json
+++ b/package.json
@@ -2,16 +2,31 @@
   "name": "zinfer",
   "version": "0.1.0",
   "description": "Extract input/output types from Zod schemas",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "keywords": [
+    "schema",
+    "type-extraction",
+    "typescript",
+    "zod"
+  ],
+  "license": "MIT",
   "bin": {
     "zinfer": "./bin/zinfer"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check ."
   },
   "dependencies": {
     "commander": "^14.0.2",
@@ -20,6 +35,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
+    "oxfmt": "^0.23.0",
+    "oxlint": "^1.38.0",
     "typescript": "^5.7.2",
     "vitest": "^4.0.16",
     "zod": "^4.3.5"
@@ -27,16 +44,5 @@
   "peerDependencies": {
     "typescript": ">=5.0.0",
     "zod": ">=3.0.0"
-  },
-  "files": [
-    "dist",
-    "bin"
-  ],
-  "keywords": [
-    "zod",
-    "typescript",
-    "type-extraction",
-    "schema"
-  ],
-  "license": "MIT"
+  }
 }

--- a/src/core/brand-detector.ts
+++ b/src/core/brand-detector.ts
@@ -1,10 +1,4 @@
-import {
-  SourceFile,
-  Node,
-  SyntaxKind,
-  CallExpression,
-  PropertyAccessExpression,
-} from "ts-morph";
+import { SourceFile, Node, CallExpression } from "ts-morph";
 
 /**
  * Information about a branded type in a schema.
@@ -32,10 +26,7 @@ export class BrandDetector {
    * @param schemaNames - Set of schema names to analyze
    * @returns Map of schema name to brand information
    */
-  detectBrands(
-    sourceFile: SourceFile,
-    schemaNames: Set<string>
-  ): SchemaBrandMap {
+  detectBrands(sourceFile: SourceFile, schemaNames: Set<string>): SchemaBrandMap {
     const result: SchemaBrandMap = new Map();
 
     const statements = sourceFile.getVariableStatements();
@@ -109,10 +100,7 @@ export class BrandDetector {
   /**
    * Extracts brand information from a .brand<...>() call.
    */
-  private extractBrandFromCall(
-    node: CallExpression,
-    fieldPath: string
-  ): BrandInfo | null {
+  private extractBrandFromCall(node: CallExpression, fieldPath: string): BrandInfo | null {
     const expr = node.getExpression();
     if (!Node.isPropertyAccessExpression(expr)) {
       return null;

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
-import { resolve, dirname } from "path";
+import { resolve } from "path";
 import { pathToFileURL } from "url";
 
 /**
@@ -103,10 +103,7 @@ export class ConfigLoader {
       const module = await import(fileUrl);
       return module.default || module;
     } catch (error) {
-      console.warn(
-        `Warning: Failed to load config from ${configPath}:`,
-        (error as Error).message
-      );
+      console.warn(`Warning: Failed to load config from ${configPath}:`, (error as Error).message);
       return {};
     }
   }
@@ -114,9 +111,7 @@ export class ConfigLoader {
   /**
    * Loads configuration from package.json's "zinfer" field.
    */
-  private async loadFromPackageJson(
-    packageJsonPath: string
-  ): Promise<ZinferConfig | null> {
+  private async loadFromPackageJson(packageJsonPath: string): Promise<ZinferConfig | null> {
     try {
       const content = await readFile(packageJsonPath, "utf-8");
       const packageJson = JSON.parse(content);
@@ -145,13 +140,11 @@ export function createConfigLoader(): ConfigLoader {
  */
 export function mergeConfig(
   configFile: ZinferConfig,
-  cliOptions: Partial<ZinferConfig>
+  cliOptions: Partial<ZinferConfig>,
 ): ZinferConfig {
   return {
     ...configFile,
-    ...Object.fromEntries(
-      Object.entries(cliOptions).filter(([_, v]) => v !== undefined)
-    ),
+    ...Object.fromEntries(Object.entries(cliOptions).filter(([_, v]) => v !== undefined)),
   };
 }
 

--- a/src/core/description-extractor.ts
+++ b/src/core/description-extractor.ts
@@ -36,7 +36,7 @@ export class DescriptionExtractor {
    */
   async extractDescriptions(
     filePath: string,
-    schemaNames: string[]
+    schemaNames: string[],
   ): Promise<Map<string, SchemaDescription>> {
     const result = new Map<string, SchemaDescription>();
 
@@ -61,7 +61,7 @@ export class DescriptionExtractor {
       // If import fails, return empty descriptions (non-blocking)
       console.warn(
         `Warning: Could not import ${filePath} for description extraction:`,
-        (error as Error).message
+        (error as Error).message,
       );
     }
 
@@ -71,10 +71,7 @@ export class DescriptionExtractor {
   /**
    * Extracts descriptions from a Zod schema.
    */
-  private extractFromSchema(
-    schema: unknown,
-    schemaName: string
-  ): SchemaDescription {
+  private extractFromSchema(schema: unknown, schemaName: string): SchemaDescription {
     const fields: FieldDescription[] = [];
 
     // Get schema-level description
@@ -96,7 +93,7 @@ export class DescriptionExtractor {
   private extractFieldDescriptions(
     schema: unknown,
     prefix: string,
-    fields: FieldDescription[]
+    fields: FieldDescription[],
   ): void {
     if (!schema || typeof schema !== "object") {
       return;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -5,7 +5,7 @@ export class ZinferError extends Error {
   constructor(
     message: string,
     public readonly code: string,
-    public readonly hint?: string
+    public readonly hint?: string,
   ) {
     super(message);
     this.name = "ZinferError";
@@ -27,20 +27,12 @@ export class ZinferError extends Error {
  * Error when a schema is not found in a file.
  */
 export class SchemaNotFoundError extends ZinferError {
-  constructor(
-    schemaName: string,
-    filePath: string,
-    availableSchemas?: string[]
-  ) {
+  constructor(schemaName: string, filePath: string, availableSchemas?: string[]) {
     const hint = availableSchemas?.length
       ? `Available schemas: ${availableSchemas.join(", ")}`
       : "Make sure the schema is exported and uses Zod (z.object, z.string, etc.)";
 
-    super(
-      `Schema "${schemaName}" not found in ${filePath}`,
-      "SCHEMA_NOT_FOUND",
-      hint
-    );
+    super(`Schema "${schemaName}" not found in ${filePath}`, "SCHEMA_NOT_FOUND", hint);
     this.name = "SchemaNotFoundError";
   }
 }
@@ -50,20 +42,19 @@ export class SchemaNotFoundError extends ZinferError {
  */
 export class NoSchemasFoundError extends ZinferError {
   constructor(filePaths: string[], requestedSchemas?: string[]) {
-    const files =
-      filePaths.length === 1 ? filePaths[0] : `${filePaths.length} files`;
+    const files = filePaths.length === 1 ? filePaths[0] : `${filePaths.length} files`;
 
     if (requestedSchemas?.length) {
       super(
         `Requested schemas not found: ${requestedSchemas.join(", ")}`,
         "NO_SCHEMAS_FOUND",
-        `These schemas were not found in ${files}. Check schema names are correct.`
+        `These schemas were not found in ${files}. Check schema names are correct.`,
       );
     } else {
       super(
         `No Zod schemas found in ${files}`,
         "NO_SCHEMAS_FOUND",
-        "Ensure schemas are exported and use Zod syntax (z.object, z.string, etc.)"
+        "Ensure schemas are exported and use Zod syntax (z.object, z.string, etc.)",
       );
     }
     this.name = "NoSchemasFoundError";
@@ -78,7 +69,7 @@ export class NoFilesMatchedError extends ZinferError {
     super(
       `No files matched the pattern(s): ${patterns.join(", ")}`,
       "NO_FILES_MATCHED",
-      "Check that the file paths or glob patterns are correct"
+      "Check that the file paths or glob patterns are correct",
     );
     this.name = "NoFilesMatchedError";
   }
@@ -91,13 +82,9 @@ export class TypeScriptError extends ZinferError {
   constructor(
     message: string,
     public readonly filePath?: string,
-    public readonly diagnostics?: string[]
+    public readonly diagnostics?: string[],
   ) {
-    super(
-      message,
-      "TYPESCRIPT_ERROR",
-      "Fix the TypeScript errors in your source file"
-    );
+    super(message, "TYPESCRIPT_ERROR", "Fix the TypeScript errors in your source file");
     this.name = "TypeScriptError";
   }
 
@@ -128,16 +115,12 @@ export class TypeScriptError extends ZinferError {
  * Error when type extraction fails.
  */
 export class ExtractionError extends ZinferError {
-  constructor(
-    schemaName: string,
-    filePath: string,
-    originalError?: Error
-  ) {
+  constructor(schemaName: string, filePath: string, originalError?: Error) {
     const originalMessage = originalError?.message || "Unknown error";
     super(
       `Failed to extract types from "${schemaName}" in ${filePath}: ${originalMessage}`,
       "EXTRACTION_ERROR",
-      "This may be due to syntax errors or unsupported schema patterns"
+      "This may be due to syntax errors or unsupported schema patterns",
     );
     this.name = "ExtractionError";
   }

--- a/src/core/file-resolver.ts
+++ b/src/core/file-resolver.ts
@@ -15,7 +15,7 @@ export class FileResolver {
    */
   async resolveInputFiles(
     pattern: string | string[],
-    cwd: string = process.cwd()
+    cwd: string = process.cwd(),
   ): Promise<string[]> {
     const patterns = Array.isArray(pattern) ? pattern : [pattern];
     const allFiles: string[] = [];
@@ -44,7 +44,7 @@ export class FileResolver {
   resolveOutputPath(
     inputPath: string,
     options: OutputOptions,
-    cwd: string = process.cwd()
+    cwd: string = process.cwd(),
   ): string {
     // If outFile is specified, use it directly
     if (options.outFile) {
@@ -92,13 +92,8 @@ export class FileResolver {
    * @param vars - Variables to substitute
    * @returns Generated filename
    */
-  applyPattern(
-    pattern: string,
-    vars: { name: string; ext: string }
-  ): string {
-    return pattern
-      .replace(/\[name\]/g, vars.name)
-      .replace(/\[ext\]/g, vars.ext);
+  applyPattern(pattern: string, vars: { name: string; ext: string }): string {
+    return pattern.replace(/\[name\]/g, vars.name).replace(/\[ext\]/g, vars.ext);
   }
 
   /**

--- a/src/core/getter-resolver.ts
+++ b/src/core/getter-resolver.ts
@@ -1,11 +1,4 @@
-import {
-  SourceFile,
-  SyntaxKind,
-  Node,
-  CallExpression,
-  PropertyAccessExpression,
-  Identifier,
-} from "ts-morph";
+import { SourceFile, SyntaxKind, Node, CallExpression, PropertyAccessExpression } from "ts-morph";
 
 /**
  * Information about a getter field in a z.object schema.
@@ -62,10 +55,7 @@ export class GetterResolver {
   /**
    * Extracts getter field info from AST nodes.
    */
-  private extractGetterFieldsFromAST(
-    node: Node,
-    schemaName: string
-  ): Map<string, GetterFieldInfo> {
+  private extractGetterFieldsFromAST(node: Node, schemaName: string): Map<string, GetterFieldInfo> {
     const fieldMap = new Map<string, GetterFieldInfo>();
 
     // Find all getter declarations within the node
@@ -77,9 +67,7 @@ export class GetterResolver {
       if (!body) continue;
 
       // Find return statement
-      const returnStmt = body.getFirstDescendantByKind(
-        SyntaxKind.ReturnStatement
-      );
+      const returnStmt = body.getFirstDescendantByKind(SyntaxKind.ReturnStatement);
       if (!returnStmt) continue;
 
       const returnExpr = returnStmt.getExpression();
@@ -97,10 +85,7 @@ export class GetterResolver {
   /**
    * Parses the return expression AST to extract schema reference info.
    */
-  private parseReturnExpressionAST(
-    expr: Node,
-    schemaName: string
-  ): GetterFieldInfo | null {
+  private parseReturnExpressionAST(expr: Node, schemaName: string): GetterFieldInfo | null {
     let isArray = false;
     let isRecord = false;
     let isOptional = false;
@@ -195,9 +180,9 @@ export class GetterResolver {
    */
   resolveAnyTypes(
     typeStr: string,
-    schemaName: string,
+    _schemaName: string,
     getterFields: Map<string, GetterFieldInfo>,
-    typeName: string
+    typeName: string,
   ): string {
     let result = typeStr;
 
@@ -221,11 +206,7 @@ export class GetterResolver {
   /**
    * Replaces any type in a record field.
    */
-  private replaceRecordAny(
-    typeStr: string,
-    fieldName: string,
-    typeName: string
-  ): string {
+  private replaceRecordAny(typeStr: string, fieldName: string, typeName: string): string {
     // Find "fieldName: { [x: string]: any" or "fieldName?: { [x: string]: any"
     const fieldPatterns = [`${fieldName}: {`, `${fieldName}?: {`];
 
@@ -241,12 +222,9 @@ export class GetterResolver {
           // Find "any" after the colon
           const afterColon = typeStr.substring(colonPos).trimStart();
           if (afterColon.startsWith("any")) {
-            const anyStart = colonPos + (typeStr.substring(colonPos).indexOf("any"));
+            const anyStart = colonPos + typeStr.substring(colonPos).indexOf("any");
             const anyEnd = anyStart + 3;
-            typeStr =
-              typeStr.substring(0, anyStart) +
-              typeName +
-              typeStr.substring(anyEnd);
+            typeStr = typeStr.substring(0, anyStart) + typeName + typeStr.substring(anyEnd);
           }
         }
 
@@ -264,7 +242,7 @@ export class GetterResolver {
     typeStr: string,
     fieldName: string,
     typeName: string,
-    isArray: boolean
+    isArray: boolean,
   ): string {
     // Find "fieldName: any" or "fieldName?: any" patterns
     const fieldPatterns = [`${fieldName}: `, `${fieldName}?: `];
@@ -305,8 +283,7 @@ export class GetterResolver {
             endPos += 2;
           }
 
-          typeStr =
-            typeStr.substring(0, anyIdx) + replacement + typeStr.substring(endPos);
+          typeStr = typeStr.substring(0, anyIdx) + replacement + typeStr.substring(endPos);
         }
 
         idx = typeStr.indexOf(pattern, idx + 1);

--- a/src/core/import-resolver.ts
+++ b/src/core/import-resolver.ts
@@ -1,11 +1,5 @@
-import {
-  SourceFile,
-  Node,
-  ImportDeclaration,
-  Project,
-} from "ts-morph";
+import { SourceFile, ImportDeclaration, Project } from "ts-morph";
 import { SchemaDetector } from "./schema-detector.js";
-import type { DetectedSchema } from "./types.js";
 
 /**
  * Information about an imported schema.
@@ -44,10 +38,7 @@ export class ImportResolver {
    * @param project - The ts-morph project for module resolution
    * @returns Map of local names to imported schema info
    */
-  findImportedSchemas(
-    sourceFile: SourceFile,
-    project: Project
-  ): ImportedSchemaMap {
+  findImportedSchemas(sourceFile: SourceFile, project: Project): ImportedSchemaMap {
     const result: ImportedSchemaMap = new Map();
     const imports = sourceFile.getImportDeclarations();
 
@@ -60,11 +51,7 @@ export class ImportResolver {
       }
 
       // Resolve the module to a source file
-      const resolvedSourceFile = this.resolveImportedFile(
-        importDecl,
-        sourceFile,
-        project
-      );
+      const resolvedSourceFile = this.resolveImportedFile(importDecl, sourceFile, project);
 
       if (!resolvedSourceFile) {
         continue;
@@ -78,11 +65,7 @@ export class ImportResolver {
 
         // Find the actual source file containing the schema definition
         // This handles re-exports from index.ts files
-        const actualSource = this.findSchemaSource(
-          resolvedSourceFile,
-          importedName,
-          project
-        );
+        const actualSource = this.findSchemaSource(resolvedSourceFile, importedName, project);
 
         if (actualSource) {
           result.set(localName, {
@@ -106,7 +89,7 @@ export class ImportResolver {
     sourceFile: SourceFile,
     schemaName: string,
     project: Project,
-    visited: Set<string> = new Set()
+    visited: Set<string> = new Set(),
   ): { sourceFile: SourceFile; schemaName: string } | undefined {
     const filePath = sourceFile.getFilePath();
 
@@ -133,18 +116,9 @@ export class ImportResolver {
 
       if (namedExports.length === 0) {
         // This is "export * from './module'" - follow it
-        const reExportedFile = this.resolveModuleSpecifier(
-          sourceFile,
-          moduleSpecifier,
-          project
-        );
+        const reExportedFile = this.resolveModuleSpecifier(sourceFile, moduleSpecifier, project);
         if (reExportedFile) {
-          const found = this.findSchemaSource(
-            reExportedFile,
-            schemaName,
-            project,
-            visited
-          );
+          const found = this.findSchemaSource(reExportedFile, schemaName, project, visited);
           if (found) {
             return found;
           }
@@ -158,15 +132,10 @@ export class ImportResolver {
             const reExportedFile = this.resolveModuleSpecifier(
               sourceFile,
               moduleSpecifier,
-              project
+              project,
             );
             if (reExportedFile) {
-              return this.findSchemaSource(
-                reExportedFile,
-                originalName,
-                project,
-                visited
-              );
+              return this.findSchemaSource(reExportedFile, originalName, project, visited);
             }
           }
         }
@@ -182,7 +151,7 @@ export class ImportResolver {
   private resolveModuleSpecifier(
     fromFile: SourceFile,
     moduleSpecifier: string,
-    project: Project
+    project: Project,
   ): SourceFile | undefined {
     const sourceDir = fromFile.getDirectoryPath();
     const possiblePaths = [
@@ -215,7 +184,7 @@ export class ImportResolver {
   private resolveImportedFile(
     importDecl: ImportDeclaration,
     sourceFile: SourceFile,
-    project: Project
+    project: Project,
   ): SourceFile | undefined {
     const moduleSpecifier = importDecl.getModuleSpecifierValue();
 
@@ -267,10 +236,7 @@ export class ImportResolver {
   extractImportedSchemaTypes(
     importedSchemas: ImportedSchemaMap,
     project: Project,
-    extractType: (
-      sourceFile: SourceFile,
-      schemaName: string
-    ) => { input: string; output: string }
+    extractType: (sourceFile: SourceFile, schemaName: string) => { input: string; output: string },
   ): Map<string, { input: string; output: string }> {
     const result = new Map<string, { input: string; output: string }>();
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,13 +1,6 @@
-export {
-  NORMALIZE_TYPE_DEFINITION,
-  createTempTypeAlias,
-  TEMP_TYPE_NAMES,
-} from "./normalizer.js";
+export { NORMALIZE_TYPE_DEFINITION, createTempTypeAlias, TEMP_TYPE_NAMES } from "./normalizer.js";
 
-export {
-  ZodTypeExtractor,
-  type ExtractOptions,
-} from "./extractor.js";
+export { ZodTypeExtractor, type ExtractOptions } from "./extractor.js";
 
 export {
   formatResult,
@@ -25,10 +18,7 @@ export { NameMapper, createNameMapper } from "./name-mapper.js";
 
 export { FileResolver, createFileResolver } from "./file-resolver.js";
 
-export {
-  DescriptionExtractor,
-  createDescriptionExtractor,
-} from "./description-extractor.js";
+export { DescriptionExtractor, createDescriptionExtractor } from "./description-extractor.js";
 
 export {
   ZinferError,

--- a/src/core/name-mapper.ts
+++ b/src/core/name-mapper.ts
@@ -48,10 +48,7 @@ export class NameMapper {
 
     // Remove suffix if specified
     let baseName = schemaName;
-    if (
-      this.options.removeSuffix &&
-      schemaName.endsWith(this.options.removeSuffix)
-    ) {
+    if (this.options.removeSuffix && schemaName.endsWith(this.options.removeSuffix)) {
       baseName = schemaName.slice(0, -this.options.removeSuffix.length);
     }
 
@@ -90,7 +87,7 @@ export class NameMapper {
  * @returns A function that maps schema names to type names
  */
 export function createNameMapper(
-  options: NameMappingOptions = {}
+  options: NameMappingOptions = {},
 ): (schemaName: string) => MappedTypeName {
   const mapper = new NameMapper(options);
   return (schemaName: string) => mapper.map(schemaName);

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -39,10 +39,7 @@ type __Normalize<T> =
  * @param typeKind - Either 'input' or 'output' to specify which type to extract
  * @returns A TypeScript type alias string to be injected in-memory
  */
-export function createTempTypeAlias(
-  schemaName: string,
-  typeKind: "input" | "output"
-): string {
+export function createTempTypeAlias(schemaName: string, typeKind: "input" | "output"): string {
   const typeName = typeKind === "input" ? "__TempInput" : "__TempOutput";
   return `type ${typeName} = __Normalize<z.${typeKind}<typeof ${schemaName}>>;`;
 }
@@ -51,8 +48,4 @@ export function createTempTypeAlias(
  * Names of temporary types that are injected during extraction.
  * These should be cleaned up after extraction is complete.
  */
-export const TEMP_TYPE_NAMES = [
-  "__Normalize",
-  "__TempInput",
-  "__TempOutput",
-] as const;
+export const TEMP_TYPE_NAMES = ["__Normalize", "__TempInput", "__TempOutput"] as const;

--- a/src/core/schema-detector.ts
+++ b/src/core/schema-detector.ts
@@ -1,10 +1,4 @@
-import {
-  SourceFile,
-  VariableDeclaration,
-  SyntaxKind,
-  Node,
-  TypeNode,
-} from "ts-morph";
+import { SourceFile, VariableDeclaration } from "ts-morph";
 import type { DetectedSchema } from "./types.js";
 
 /**
@@ -44,9 +38,7 @@ export class SchemaDetector {
       const namedExports = exportDecl.getNamedExports();
       for (const namedExport of namedExports) {
         const aliasNode = namedExport.getAliasNode();
-        const exportedName = aliasNode
-          ? aliasNode.getText()
-          : namedExport.getName();
+        const exportedName = aliasNode ? aliasNode.getText() : namedExport.getName();
 
         // Check if the original variable is a Zod schema
         const originalName = namedExport.getName();
@@ -168,9 +160,7 @@ export class SchemaDetector {
    * @param declaration - The variable declaration to check
    * @returns The explicit type string if found, undefined otherwise
    */
-  private extractExplicitType(
-    declaration: VariableDeclaration
-  ): string | undefined {
+  private extractExplicitType(declaration: VariableDeclaration): string | undefined {
     const typeNode = declaration.getTypeNode();
     if (!typeNode) {
       return undefined;
@@ -179,8 +169,7 @@ export class SchemaDetector {
     const typeText = typeNode.getText();
 
     // Match patterns like z.ZodType<T>, z.ZodSchema<T>, ZodType<T>, ZodSchema<T>
-    const zodTypePattern =
-      /^(?:z\.)?(?:ZodType|ZodSchema|ZodEffects)<\s*(.+?)(?:\s*,\s*.+)?\s*>$/;
+    const zodTypePattern = /^(?:z\.)?(?:ZodType|ZodSchema|ZodEffects)<\s*(.+?)(?:\s*,\s*.+)?\s*>$/;
     const match = typeText.match(zodTypePattern);
 
     if (match) {

--- a/src/core/schema-reference-analyzer.ts
+++ b/src/core/schema-reference-analyzer.ts
@@ -1,10 +1,4 @@
-import {
-  SourceFile,
-  SyntaxKind,
-  Node,
-  CallExpression,
-  PropertyAccessExpression,
-} from "ts-morph";
+import { SourceFile, Node, CallExpression } from "ts-morph";
 
 /**
  * Information about a schema reference within another schema.
@@ -51,10 +45,7 @@ export class SchemaReferenceAnalyzer {
   /**
    * Analyzes a source file to find all schema references.
    */
-  analyzeReferences(
-    sourceFile: SourceFile,
-    schemaNames: Set<string>
-  ): SchemaReferenceMap {
+  analyzeReferences(sourceFile: SourceFile, schemaNames: Set<string>): SchemaReferenceMap {
     const result: SchemaReferenceMap = new Map();
 
     const statements = sourceFile.getVariableStatements();
@@ -79,10 +70,7 @@ export class SchemaReferenceAnalyzer {
   /**
    * Analyzes a source file to find union schema references.
    */
-  analyzeUnionReferences(
-    sourceFile: SourceFile,
-    schemaNames: Set<string>
-  ): UnionReferenceMap {
+  analyzeUnionReferences(sourceFile: SourceFile, schemaNames: Set<string>): UnionReferenceMap {
     const result: UnionReferenceMap = new Map();
 
     const statements = sourceFile.getVariableStatements();
@@ -110,7 +98,7 @@ export class SchemaReferenceAnalyzer {
   private findUnionReference(
     node: Node,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): UnionReferenceInfo | undefined {
     // Check if this is a z.discriminatedUnion() or z.union() call
     if (!Node.isCallExpression(node)) {
@@ -146,7 +134,7 @@ export class SchemaReferenceAnalyzer {
   private parseDiscriminatedUnion(
     node: CallExpression,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): UnionReferenceInfo | undefined {
     const args = node.getArguments();
     if (args.length < 2) {
@@ -181,7 +169,7 @@ export class SchemaReferenceAnalyzer {
   private parseUnion(
     node: CallExpression,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): UnionReferenceInfo | undefined {
     const args = node.getArguments();
     if (args.length < 1) {
@@ -208,7 +196,7 @@ export class SchemaReferenceAnalyzer {
   private extractSchemaArrayMembers(
     node: Node,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): string[] {
     if (!Node.isArrayLiteralExpression(node)) {
       return [];
@@ -233,7 +221,7 @@ export class SchemaReferenceAnalyzer {
   private findSchemaReferences(
     node: Node,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): SchemaReferenceInfo[] {
     const refs: SchemaReferenceInfo[] = [];
 
@@ -258,7 +246,7 @@ export class SchemaReferenceAnalyzer {
             initializer,
             fieldName,
             schemaNames,
-            currentSchema
+            currentSchema,
           );
           if (refInfo) {
             refs.push(refInfo);
@@ -303,7 +291,7 @@ export class SchemaReferenceAnalyzer {
     node: Node,
     fieldPath: string,
     schemaNames: Set<string>,
-    currentSchema: string
+    currentSchema: string,
   ): SchemaReferenceInfo | null {
     let isArray = false;
     let isRecord = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ import { formatResult } from "./core/index.js";
 export function extractZodTypes(
   filePath: string,
   schemaName: string,
-  tsconfigPath?: string
+  tsconfigPath?: string,
 ): { input: string; output: string } {
   const extractor = new ZodTypeExtractor(tsconfigPath);
   const result = extractor.extract({ filePath, schemaName });
@@ -94,7 +94,7 @@ export function extractZodTypes(
 export function extractAndFormat(
   filePath: string,
   schemaName: string,
-  tsconfigPath?: string
+  tsconfigPath?: string,
 ): string {
   const extractor = new ZodTypeExtractor(tsconfigPath);
   const result: ExtractResult = extractor.extract({ filePath, schemaName });
@@ -108,10 +108,7 @@ export function extractAndFormat(
  * @param tsconfigPath - Optional path to tsconfig.json
  * @returns Array of extraction results
  */
-export function extractAllSchemas(
-  filePath: string,
-  tsconfigPath?: string
-): ExtractResult[] {
+export function extractAllSchemas(filePath: string, tsconfigPath?: string): ExtractResult[] {
   const extractor = new ZodTypeExtractor(tsconfigPath);
   return extractor.extractAll(filePath);
 }
@@ -128,12 +125,8 @@ export function generateTypeDeclarations(
   options: {
     nameMapping?: NameMappingOptions;
     declaration?: DeclarationOptions;
-  } = {}
+  } = {},
 ): string {
   const mapper = new NameMapper(options.nameMapping || {});
-  return generateDeclarationFile(
-    results,
-    mapper.createMapFunction(),
-    options.declaration || {}
-  );
+  return generateDeclarationFile(results, mapper.createMapFunction(), options.declaration || {});
 }

--- a/tests/__file_snapshots__/utility-types-schema.ts
+++ b/tests/__file_snapshots__/utility-types-schema.ts
@@ -50,6 +50,32 @@ export type RequiredUserOutput = {
   age: number;
 };
 
+export type NestedInput = {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    age: number;
+  };
+  settings: {
+    theme: string;
+    notifications: boolean;
+  };
+};
+
+export type NestedOutput = {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    age: number;
+  };
+  settings: {
+    theme: string;
+    notifications: boolean;
+  };
+};
+
 export type DeepPartialNestedInput = {
   user?: {
     id?: string | undefined;

--- a/tests/__snapshots__/schema-detector.test.ts.snap
+++ b/tests/__snapshots__/schema-detector.test.ts.snap
@@ -125,7 +125,7 @@ exports[`SchemaDetector > detectExportedSchemas > should detect schemas from uti
   },
   {
     "explicitType": undefined,
-    "isExported": false,
+    "isExported": true,
     "line": 33,
     "name": "NestedSchema",
   },

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { resolve } from "path";
 import { ZodTypeExtractor } from "../src/core/extractor.js";
-import {
-  formatAsDeclaration,
-  generateDeclarationFile
-} from "../src/core/type-printer.js";
+import { generateDeclarationFile } from "../src/core/type-printer.js";
 import { createNameMapper } from "../src/core/name-mapper.js";
 import { execSync } from "child_process";
 import { readdirSync } from "fs";
@@ -17,8 +14,8 @@ const mapName = createNameMapper({ removeSuffix: "Schema" });
 afterAll(() => {
   try {
     const snapshotFiles = readdirSync(snapshotsDir)
-      .filter(f => f.endsWith('.ts'))
-      .map(f => resolve(snapshotsDir, f));
+      .filter((f) => f.endsWith(".ts"))
+      .map((f) => resolve(snapshotsDir, f));
 
     if (snapshotFiles.length === 0) {
       console.log("No snapshot files found to type-check");
@@ -30,25 +27,26 @@ afterAll(() => {
     for (const file of snapshotFiles) {
       try {
         execSync(`npx tsc --noEmit "${file}"`, {
-          stdio: 'pipe',
-          encoding: 'utf-8'
+          stdio: "pipe",
+          encoding: "utf-8",
         });
-        console.log(`✓ ${file.split('/').pop()}`);
+        console.log(`✓ ${file.split("/").pop()}`);
       } catch (error: any) {
         // Filter out zod locale errors
         // tsc outputs errors to stdout, not stderr
-        const output = (error.stdout || error.stderr || '');
+        const output = error.stdout || error.stderr || "";
         const relevantErrors = output
-          .split('\n')
-          .filter((line: string) =>
-            line.includes('error TS') &&
-            !line.includes('esModuleInterop') &&
-            !line.includes('locales')
+          .split("\n")
+          .filter(
+            (line: string) =>
+              line.includes("error TS") &&
+              !line.includes("esModuleInterop") &&
+              !line.includes("locales"),
           )
-          .join('\n');
+          .join("\n");
 
         if (relevantErrors) {
-          console.error(`✗ ${file.split('/').pop()}`);
+          console.error(`✗ ${file.split("/").pop()}`);
           console.error(relevantErrors);
           throw new Error(`Type check failed for ${file}`);
         }
@@ -57,7 +55,7 @@ afterAll(() => {
 
     console.log(`\n✓ All ${snapshotFiles.length} snapshot files passed type-check\n`);
   } catch (error: any) {
-    if (error.code === 'ENOENT') {
+    if (error.code === "ENOENT") {
       console.log("Snapshots directory not found, skipping type-check");
     } else {
       throw error;
@@ -70,220 +68,132 @@ describe("ZodTypeExtractor - Generated TypeScript Declarations", () => {
 
   describe("basic-schema.ts", () => {
     it("should generate TypeScript declarations", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "basic-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "basic-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/basic-schema.ts");
     });
   });
 
   describe("transform-schema.ts", () => {
     it("should generate TypeScript declarations with transforms", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "transform-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "transform-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/transform-schema.ts");
     });
   });
 
   describe("nested-schema.ts", () => {
     it("should generate TypeScript declarations with nested objects", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "nested-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "nested-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/nested-schema.ts");
     });
   });
 
   describe("union-schema.ts", () => {
     it("should generate TypeScript declarations with unions", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "union-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "union-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/union-schema.ts");
     });
   });
 
   describe("intersection-schema.ts", () => {
     it("should generate TypeScript declarations with intersections", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "intersection-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "intersection-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/intersection-schema.ts");
     });
   });
 
   describe("enum-schema.ts", () => {
     it("should generate TypeScript declarations with enums", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "enum-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "enum-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/enum-schema.ts");
     });
   });
 
   describe("utility-types-schema.ts", () => {
     it("should generate TypeScript declarations with utility types", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "utility-types-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "utility-types-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/utility-types-schema.ts");
     });
   });
 
   describe("multi-schema.ts", () => {
     it("should generate TypeScript declarations for multiple schemas", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "multi-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "multi-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/multi-schema.ts");
     });
   });
 
   describe("lazy-schema.ts", () => {
     it("should generate TypeScript declarations with circular references", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "lazy-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "lazy-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/lazy-schema.ts");
     });
   });
 
   describe("getter-schema.ts", () => {
     it("should generate TypeScript declarations with getter-based recursive schemas", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "getter-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "getter-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/getter-schema.ts");
     });
   });
 
   describe("cross-ref-schema.ts", () => {
     it("should generate TypeScript declarations with cross-references", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "cross-ref-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "cross-ref-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/cross-ref-schema.ts");
     });
   });
 
   describe("mixed-export-schema.ts", () => {
     it("should generate TypeScript declarations respecting export status", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "mixed-export-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "mixed-export-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/mixed-export-schema.ts");
     });
   });
 
   describe("union-ref-schema.ts", () => {
     it("should generate TypeScript declarations with union references", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "union-ref-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "union-ref-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/union-ref-schema.ts");
     });
   });
 
   describe("brand-schema.ts", () => {
     it("should generate TypeScript declarations with brand information", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "brand-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "brand-schema.ts"));
+      const output = generateDeclarationFile(results, mapName);
       await expect(output).toMatchFileSnapshot("__file_snapshots__/brand-schema.ts");
     });
   });
 
   describe("declaration options", () => {
     it("should generate with inputOnly option", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "transform-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName,
-        { inputOnly: true }
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "transform-schema.ts"));
+      const output = generateDeclarationFile(results, mapName, { inputOnly: true });
       await expect(output).toMatchFileSnapshot("__file_snapshots__/options-inputOnly.ts");
     });
 
     it("should generate with outputOnly option", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "transform-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName,
-        { outputOnly: true }
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "transform-schema.ts"));
+      const output = generateDeclarationFile(results, mapName, { outputOnly: true });
       await expect(output).toMatchFileSnapshot("__file_snapshots__/options-outputOnly.ts");
     });
 
     it("should generate with unifyIfSame option", async () => {
-      const results = extractor.extractAll(
-        resolve(fixturesDir, "basic-schema.ts")
-      );
-      const output = generateDeclarationFile(
-        results,
-        mapName,
-        { unifyIfSame: true }
-      );
+      const results = extractor.extractAll(resolve(fixturesDir, "basic-schema.ts"));
+      const output = generateDeclarationFile(results, mapName, { unifyIfSame: true });
       await expect(output).toMatchFileSnapshot("__file_snapshots__/options-unifyIfSame.ts");
     });
   });

--- a/tests/fixtures/described-schema.ts
+++ b/tests/fixtures/described-schema.ts
@@ -9,9 +9,7 @@ export const UserSchema = z
     name: z.string().min(1).describe("User's display name"),
     email: z.string().email().describe("User's email address"),
     age: z.number().int().positive().optional().describe("User's age in years"),
-    role: z
-      .enum(["admin", "user", "guest"])
-      .describe("User's role in the system"),
+    role: z.enum(["admin", "user", "guest"]).describe("User's role in the system"),
   })
   .describe("User account information");
 

--- a/tests/fixtures/lazy-schema.ts
+++ b/tests/fixtures/lazy-schema.ts
@@ -40,5 +40,5 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
     z.null(),
     z.array(JsonValueSchema),
     z.record(z.string(), JsonValueSchema),
-  ])
+  ]),
 );

--- a/tests/fixtures/union-ref-schema.ts
+++ b/tests/fixtures/union-ref-schema.ts
@@ -24,11 +24,7 @@ export const BirdSchema = z.object({
 /**
  * Discriminated union using schema references
  */
-export const PetSchema = z.discriminatedUnion("kind", [
-  DogSchema,
-  CatSchema,
-  BirdSchema,
-]);
+export const PetSchema = z.discriminatedUnion("kind", [DogSchema, CatSchema, BirdSchema]);
 
 /**
  * Regular union using schema references

--- a/tests/fixtures/utility-types-schema.ts
+++ b/tests/fixtures/utility-types-schema.ts
@@ -30,7 +30,7 @@ export const RequiredUserSchema = UserSchema.partial().required();
 /**
  * DeepPartial - nested partial (manual implementation for Zod 4)
  */
-const NestedSchema = z.object({
+export const NestedSchema = z.object({
   user: UserSchema,
   settings: z.object({
     theme: z.string(),
@@ -38,10 +38,14 @@ const NestedSchema = z.object({
   }),
 });
 
-export const DeepPartialNestedSchema = z.object({
-  user: UserSchema.partial(),
-  settings: z.object({
-    theme: z.string(),
-    notifications: z.boolean(),
-  }).partial(),
-}).partial();
+export const DeepPartialNestedSchema = z
+  .object({
+    user: UserSchema.partial(),
+    settings: z
+      .object({
+        theme: z.string(),
+        notifications: z.boolean(),
+      })
+      .partial(),
+  })
+  .partial();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ES2022"],
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,
@@ -13,8 +18,8 @@
     "rootDir": "src",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": false
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- Add oxfmt and oxlint as dev dependencies
- Create .oxfmtrc.json and oxlint.json configuration files
- Add format, format:check, lint, and typecheck npm scripts
- Update tsconfig.json with stricter type checking options
- Fix unused imports and variables across codebase
- Format codebase with oxfmt