### PR TITLE
fix: override minimumReleaseAge to 7 days for npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
   "prConcurrentLimit": 5,
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
     },


### PR DESCRIPTION
## Summary

- Add packageRule to explicitly set `minimumReleaseAge: "7 days"` for npm datasource
- Fixes Renovate artifact update failures on all npm dependency PRs since 2026-03-31

## Root Cause

`config:best-practices` includes `security:minimumReleaseAgeNpm`, which sets `minimumReleaseAge` to **3 days** via packageRules. Since packageRules take precedence over top-level settings, our `minimumReleaseAge: "7 days"` was being overridden.

This caused a mismatch with `.npmrc`'s `minimum-release-age=10080` (7 days): Renovate created PRs after 3 days, but pnpm refused to install packages younger than 7 days, failing lockfile generation (`renovate/artifacts: fail`).

## Affected PRs

All open npm Renovate PRs should auto-resolve after this merges and Renovate rebases them:
- #115, #113, #108, #107