### PR TITLE
Add support for subpath imports (package.json imports field)

### DIFF
--- a/.changeset/subpath-import-support.md
+++ b/.changeset/subpath-import-support.md
@@ -1,0 +1,5 @@
+---
+"zinfer": minor
+---
+
+Support subpath imports (the package.json `imports` field), including the `#/*` wildcard form supported by TypeScript 6 / Node 26. Schemas imported via `#`-prefixed specifiers are now resolved instead of being skipped as bare module specifiers. ts-morph is upgraded to v28 (which bundles TypeScript 6), so the `#/*` pattern is resolved natively by TypeScript's own module resolution.

--- a/README.md
+++ b/README.md
@@ -488,6 +488,33 @@ Re-run with `--generate-tests` after modifying schemas to continuously verify ty
 - Circular references: `z.lazy()`, getter patterns
 - Descriptions: `.describe()`
 - Branded types: `.brand()`
+- Imported schemas: relative imports and subpath imports (package.json `imports` field, including the `#/*` form)
+
+## Subpath Imports
+
+Schemas imported via the package.json [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field are resolved automatically, including the `#/*` wildcard form supported by TypeScript 6 / Node 26.
+
+```json
+// package.json
+{
+  "imports": {
+    "#/*": "./src/*"
+  }
+}
+```
+
+```typescript
+// src/user.ts
+import { z } from "zod";
+import { AddressSchema } from "#/address.js";
+
+export const UserSchema = z.object({
+  name: z.string(),
+  address: AddressSchema,
+});
+```
+
+The imported `AddressSchema` is resolved through the nearest package.json `imports` map (wildcard, exact, and conditional targets are all supported) so that its type is inlined into the generated output.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob": "^13.0.0",
     "jiti": "^2.6.1",
     "pathe": "^2.0.3",
-    "ts-morph": "^27.0.2"
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       ts-morph:
-        specifier: ^27.0.2
-        version: 27.0.2
+        specifier: ^28.0.0
+        version: 28.0.0
     devDependencies:
       '@changesets/cli':
         specifier: 2.31.0
@@ -940,8 +940,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@ts-morph/common@0.28.1':
-    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1562,8 +1562,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-morph@27.0.2:
-    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2294,7 +2294,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@ts-morph/common@0.28.1':
+  '@ts-morph/common@0.29.0':
     dependencies:
       minimatch: 10.2.4
       path-browserify: 1.0.1
@@ -2956,9 +2956,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-morph@27.0.2:
+  ts-morph@28.0.0:
     dependencies:
-      '@ts-morph/common': 0.28.1
+      '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
   tslib@2.8.1:

--- a/src/core/import-resolver.ts
+++ b/src/core/import-resolver.ts
@@ -51,8 +51,16 @@ export class ImportResolver {
     for (const importDecl of imports) {
       const moduleSpecifier = importDecl.getModuleSpecifierValue();
 
-      // Skip node_modules imports
-      if (!moduleSpecifier.startsWith(".") && !moduleSpecifier.startsWith("/")) {
+      // Skip bare module specifiers (node_modules), but allow relative,
+      // absolute, and subpath imports (package.json "imports" field, e.g.
+      // "#/schemas/user.js"). Subpath imports — including the "#/*" form — are
+      // resolved by TypeScript's own module resolution (requires the
+      // TypeScript 6 bundled by ts-morph).
+      if (
+        !moduleSpecifier.startsWith(".") &&
+        !moduleSpecifier.startsWith("/") &&
+        !moduleSpecifier.startsWith("#")
+      ) {
         continue;
       }
 

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -4,7 +4,6 @@ import { ZodTypeExtractor } from "../src/core/extractor.js";
 import { generateDeclarationFile } from "../src/core/type-printer.js";
 import { createNameMapper } from "../src/core/name-mapper.js";
 import { DescriptionExtractor } from "../src/core/description-extractor.js";
-import type { ExtractResult } from "../src/core/types.js";
 import { execSync } from "child_process";
 import { readdirSync } from "fs";
 

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -268,4 +268,32 @@ describe("ZodTypeExtractor - Generated TypeScript Declarations", () => {
       await expect(output).toMatchFileSnapshot("__file_snapshots__/options-mergeSame-multi.ts");
     });
   });
+
+  describe('subpath imports (package.json "imports" field)', () => {
+    it("should resolve schemas imported via the #/* wildcard pattern", () => {
+      const results = extractor.extractAll(resolve(fixturesDir, "subpath-import/consumer.ts"));
+      const consumer = results.find((r) => r.schemaName === "ConsumerSchema");
+
+      expect(consumer).toBeDefined();
+      // The imported SharedSchema / AnotherSharedSchema must be fully resolved
+      // (not collapsed to `any`) for the object shape to be inferred correctly.
+      expect(consumer!.input).toContain("shared: {");
+      expect(consumer!.input).toContain("id: string");
+      expect(consumer!.input).toContain("another: {");
+      expect(consumer!.input).toContain("value: number");
+      expect(consumer!.input).not.toContain("any");
+    });
+
+    it("should resolve schemas imported via an exact subpath key", () => {
+      const results = extractor.extractAll(
+        resolve(fixturesDir, "subpath-import/exact-consumer.ts"),
+      );
+      const consumer = results.find((r) => r.schemaName === "ExactConsumerSchema");
+
+      expect(consumer).toBeDefined();
+      expect(consumer!.input).toContain("shared: {");
+      expect(consumer!.input).toContain("id: string");
+      expect(consumer!.input).not.toContain("any");
+    });
+  });
 });

--- a/tests/fixtures/subpath-import/consumer.ts
+++ b/tests/fixtures/subpath-import/consumer.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { SharedSchema, AnotherSharedSchema } from "#/shared.js";
+
+export const ConsumerSchema = z.object({
+  shared: SharedSchema,
+  another: AnotherSharedSchema,
+  extra: z.boolean(),
+});

--- a/tests/fixtures/subpath-import/exact-consumer.ts
+++ b/tests/fixtures/subpath-import/exact-consumer.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { SharedSchema } from "#shared";
+
+export const ExactConsumerSchema = z.object({
+  shared: SharedSchema,
+  extra: z.boolean(),
+});

--- a/tests/fixtures/subpath-import/package.json
+++ b/tests/fixtures/subpath-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "subpath-import-fixture",
+  "type": "module",
+  "imports": {
+    "#/*": "./schemas/*",
+    "#shared": "./schemas/shared.js"
+  }
+}

--- a/tests/fixtures/subpath-import/schemas/shared.ts
+++ b/tests/fixtures/subpath-import/schemas/shared.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const SharedSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const AnotherSharedSchema = z.object({
+  value: z.number(),
+});

--- a/tests/import-resolver.test.ts
+++ b/tests/import-resolver.test.ts
@@ -74,5 +74,34 @@ describe("ImportResolver", () => {
 
       expect(importedSchemas.size).toBe(0);
     });
+
+    it("should resolve subpath imports with a wildcard pattern (#/*)", () => {
+      const consumerPath = resolve(fixturesDir, "subpath-import/consumer.ts");
+      const sourceFile = project.addSourceFileAtPath(consumerPath);
+
+      const importedSchemas = resolver.findImportedSchemas(sourceFile, project);
+
+      expect(importedSchemas.size).toBe(2);
+      expect(importedSchemas.has("SharedSchema")).toBe(true);
+      expect(importedSchemas.has("AnotherSharedSchema")).toBe(true);
+
+      const sharedInfo = importedSchemas.get("SharedSchema")!;
+      expect(sharedInfo.localName).toBe("SharedSchema");
+      expect(sharedInfo.originalName).toBe("SharedSchema");
+      expect(sharedInfo.resolved).toBe(true);
+      expect(sharedInfo.sourceFilePath).toContain("subpath-import/schemas/shared.ts");
+    });
+
+    it("should resolve exact (non-wildcard) subpath imports", () => {
+      const consumerPath = resolve(fixturesDir, "subpath-import/exact-consumer.ts");
+      const sourceFile = project.addSourceFileAtPath(consumerPath);
+
+      const importedSchemas = resolver.findImportedSchemas(sourceFile, project);
+
+      expect(importedSchemas.has("SharedSchema")).toBe(true);
+      const sharedInfo = importedSchemas.get("SharedSchema")!;
+      expect(sharedInfo.resolved).toBe(true);
+      expect(sharedInfo.sourceFilePath).toContain("subpath-import/schemas/shared.ts");
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for resolving schemas imported via the package.json `imports` field, including the `#/*` wildcard pattern supported by TypeScript 6. Subpath imports (prefixed with `#`) are now resolved instead of being skipped as bare module specifiers.

## Key Changes
- **Import Resolver**: Updated to recognize and process subpath imports (those starting with `#`) alongside relative and absolute imports, allowing TypeScript's native module resolution to handle them
- **Test Coverage**: Added comprehensive tests for both wildcard (`#/*`) and exact subpath import patterns in both the import resolver and schema extractor
- **Documentation**: Updated README to document subpath import support with examples
- **Dependencies**: Upgraded ts-morph to v28 (which bundles TypeScript 6) to enable native `#/*` wildcard pattern resolution

## Implementation Details
- Subpath imports are identified by the `#` prefix and are now passed through to TypeScript's module resolution instead of being filtered out
- The resolver leverages ts-morph's bundled TypeScript 6 to natively resolve wildcard patterns like `#/*` and exact subpath keys
- Test fixtures demonstrate both wildcard usage (`#/shared.js`) and exact key usage (`#shared`)
- Imported schemas are fully resolved and inlined into generated output, preventing type collapse to `any`

https://claude.ai/code/session_01XGzS5cpcBRsXRh6aXPKJh4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving schemas imported via `package.json` `imports` subpath mappings, including `#/*` wildcard syntax.
* **Documentation**
  * Documented “Imported schemas” → “Subpath Imports”, with examples for `package.json` and TypeScript usage.
* **Bug Fixes**
  * Improved import resolution to treat `#`-prefixed subpath specifiers as mapped imports rather than skipping them.
* **Tests**
  * Added fixture coverage and assertions for both wildcard and exact subpath import behavior.
* **Chores**
  * Upgraded the TypeScript AST tooling dependency to enable native resolution of the new pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->