### PR TITLE
fix: preserve JSDoc descriptions for #/* subpath imports on Node < 26

### DIFF
--- a/.changeset/subpath-import-jsdoc.md
+++ b/.changeset/subpath-import-jsdoc.md
@@ -1,0 +1,13 @@
+---
+"zinfer": patch
+---
+
+Preserve JSDoc/TSDoc field descriptions for schemas imported via the bare `#/*`
+subpath import form on Node < 26. Description extraction uses jiti, which
+delegates subpath-imports resolution to the running Node; only Node 26+ resolves
+the bare `#/` form natively, while older Node rejects it as an invalid internal
+imports specifier, causing the whole module import — and thus every description —
+to be dropped. The nearest `package.json` `imports` field is now read and
+registered as jiti aliases (the same mechanism already used for tsconfig
+`paths`), so `#/`, `#src/`, and exact subpath imports all keep their
+descriptions regardless of the Node version.

--- a/src/core/description-extractor.ts
+++ b/src/core/description-extractor.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { resolve } from "pathe";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "pathe";
 import { createJiti, type Jiti } from "jiti";
 import { logDebugError, logVerbose } from "./logger.js";
 import type { FieldDescription } from "./types.js";
@@ -29,13 +29,120 @@ export interface DescriptionExtractorOptions {
  * Uses jiti for TypeScript-aware module resolution (extensionless imports, path aliases).
  */
 export class DescriptionExtractor {
-  private jiti: Jiti;
+  private tsconfigAliases: Record<string, string>;
+  /** jiti instances keyed by the nearest package.json path (so each module's subpath imports resolve correctly). */
+  private jitiCache = new Map<string, Jiti>();
 
   constructor(options?: DescriptionExtractorOptions) {
-    this.jiti = createJiti(import.meta.url, {
-      ...(options?.tsconfigPath ? { alias: this.loadPathAliases(options.tsconfigPath) } : {}),
+    this.tsconfigAliases = options?.tsconfigPath ? this.loadPathAliases(options.tsconfigPath) : {};
+  }
+
+  /**
+   * Returns a jiti instance configured to resolve the module at `filePath`.
+   *
+   * Node only resolves the bare "#/" subpath import form (e.g.
+   * "#/schemas/user.js") natively from Node 26 onward; older Node rejects it as
+   * an invalid internal imports specifier. jiti delegates subpath-imports
+   * resolution to the running Node, so on Node < 26 it cannot import modules
+   * that rely on a package.json `imports` `#/*` mapping. We bridge this by
+   * reading the nearest package.json `imports` field and registering jiti
+   * aliases for it (the same mechanism we already use for tsconfig `paths`),
+   * which makes resolution work regardless of the Node version.
+   */
+  private getJiti(filePath: string): Jiti {
+    const packageJsonPath = this.findNearestPackageJson(filePath);
+    const cacheKey = packageJsonPath ?? "";
+
+    const cached = this.jitiCache.get(cacheKey);
+    if (cached) return cached;
+
+    const importAliases = packageJsonPath ? this.loadSubpathImports(packageJsonPath) : {};
+    const alias = { ...this.tsconfigAliases, ...importAliases };
+
+    const jiti = createJiti(import.meta.url, {
+      ...(Object.keys(alias).length ? { alias } : {}),
       interopDefault: false,
     });
+
+    this.jitiCache.set(cacheKey, jiti);
+    return jiti;
+  }
+
+  /**
+   * Walks up from a file to find the nearest package.json.
+   */
+  private findNearestPackageJson(filePath: string): string | undefined {
+    let dir = dirname(resolve(filePath));
+
+    while (true) {
+      const candidate = join(dir, "package.json");
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) {
+        return undefined;
+      }
+      dir = parent;
+    }
+  }
+
+  /**
+   * Loads subpath import aliases from a package.json `imports` field.
+   *
+   * Wildcard keys keep their trailing "/" (e.g. "#/*" -> "#/", "#src/*" ->
+   * "#src/") so that prefix matching never collides with unrelated keys such as
+   * an exact "#shared" import.
+   */
+  private loadSubpathImports(packageJsonPath: string): Record<string, string> {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+      const imports = pkg?.imports;
+      if (!imports || typeof imports !== "object") return {};
+
+      const packageDir = dirname(packageJsonPath);
+      const aliases: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(imports)) {
+        const target = this.resolveImportTarget(value);
+        if (!target) continue;
+
+        if (key.endsWith("*")) {
+          // Wildcard mapping: drop the trailing "*" but keep the "/" so the
+          // alias matches "#/..." / "#src/..." without matching "#shared".
+          const aliasKey = key.slice(0, -1);
+          let aliasValue = resolve(packageDir, target.replace(/\*$/, ""));
+          if (aliasKey.endsWith("/") && !aliasValue.endsWith("/")) {
+            aliasValue += "/";
+          }
+          aliases[aliasKey] = aliasValue;
+        } else {
+          aliases[key] = resolve(packageDir, target);
+        }
+      }
+
+      logVerbose(`Loaded subpath imports from ${packageJsonPath}: ${JSON.stringify(aliases)}`);
+      return aliases;
+    } catch (error) {
+      logDebugError(`Failed to load subpath imports from ${packageJsonPath}`, error);
+      return {};
+    }
+  }
+
+  /**
+   * Resolves a package.json `imports` target to a file path string.
+   * Targets may be a plain string or a conditional object.
+   */
+  private resolveImportTarget(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (value && typeof value === "object") {
+      const conditions = value as Record<string, unknown>;
+      for (const condition of ["import", "node", "default", "require"]) {
+        const resolved = this.resolveImportTarget(conditions[condition]);
+        if (resolved) return resolved;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -86,7 +193,7 @@ export class DescriptionExtractor {
       const absolutePath = resolve(filePath);
 
       // Use jiti for TypeScript-aware module resolution
-      const module = await this.jiti.import(absolutePath);
+      const module = await this.getJiti(absolutePath).import(absolutePath);
 
       const moduleObj = module as Record<string, unknown>;
 

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -294,5 +294,31 @@ describe("ZodTypeExtractor - Generated TypeScript Declarations", () => {
       expect(consumer!.input).toContain("id: string");
       expect(consumer!.input).not.toContain("any");
     });
+
+    it("should preserve field descriptions when a schema imports via the #/* wildcard pattern", async () => {
+      const filePath = resolve(fixturesDir, "subpath-import/described-consumer.ts");
+      const descriptionExtractor = new DescriptionExtractor();
+
+      const descriptions = await descriptionExtractor.extractDescriptions(filePath, [
+        "DescribedConsumerSchema",
+      ]);
+
+      const desc = descriptions.get("DescribedConsumerSchema");
+      const nameField = desc?.fields.find((f) => f.path === "name");
+      expect(nameField?.description).toBe("The user's name");
+    });
+
+    it("should preserve field descriptions when a schema imports via a named subpath prefix (#src/*)", async () => {
+      const filePath = resolve(fixturesDir, "subpath-import/described-named-consumer.ts");
+      const descriptionExtractor = new DescriptionExtractor();
+
+      const descriptions = await descriptionExtractor.extractDescriptions(filePath, [
+        "DescribedNamedConsumerSchema",
+      ]);
+
+      const desc = descriptions.get("DescribedNamedConsumerSchema");
+      const nameField = desc?.fields.find((f) => f.path === "name");
+      expect(nameField?.description).toBe("The user's name");
+    });
   });
 });

--- a/tests/fixtures/subpath-import/described-consumer.ts
+++ b/tests/fixtures/subpath-import/described-consumer.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { SharedSchema } from "#/shared.js";
+
+export const DescribedConsumerSchema = z.object({
+  shared: SharedSchema,
+  name: z.string().describe("The user's name"),
+});

--- a/tests/fixtures/subpath-import/described-named-consumer.ts
+++ b/tests/fixtures/subpath-import/described-named-consumer.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { SharedSchema } from "#src/shared.js";
+
+export const DescribedNamedConsumerSchema = z.object({
+  shared: SharedSchema,
+  name: z.string().describe("The user's name"),
+});

--- a/tests/fixtures/subpath-import/package.json
+++ b/tests/fixtures/subpath-import/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "imports": {
     "#/*": "./schemas/*",
+    "#src/*": "./schemas/*",
     "#shared": "./schemas/shared.js"
   }
 }


### PR DESCRIPTION
## Summary

- Fix per-field JSDoc/TSDoc descriptions being dropped when a Zod schema is imported through the bare `#/*` subpath import form (package.json `imports`) on Node < 26.
- Root cause: description extraction uses jiti, which delegates subpath-imports resolution to the running Node. Only Node 26+ resolves the bare `#/` form natively; older Node rejects it as an invalid internal imports specifier, so the whole dynamic import — and thus every description — was dropped. Type resolution was unaffected because it uses ts-morph's bundled TypeScript 6.
- Fix: read the nearest `package.json` `imports` field and register it as jiti aliases (the same mechanism already used for tsconfig `paths`). Wildcard keys keep their trailing `/` (`#/*` -> `#/`, `#src/*` -> `#src/`) so prefix matching never collides with exact keys like `#shared`. Descriptions now resolve for `#/`, `#src/`, and exact subpath imports regardless of the Node version.

## Tests

- Added regression tests covering description preservation for the `#/*` wildcard form and the named `#src/*` prefix.

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Preserved JSDoc/TSDoc field descriptions when schemas are imported via package.json subpath import mappings (including `#/*` and `#src/*` forms), fixing cases where descriptions could be dropped on older Node versions.

* **Tests**
  * Added additional Vitest coverage for subpath import scenarios, validating that the `name` field description is extracted as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->