### PR TITLE
build: approve esbuild and lefthook build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  lefthook: true


### PR DESCRIPTION
## Summary

- Fix the `Release` workflow failing at `pnpm install --frozen-lockfile` with `ERR_PNPM_IGNORED_BUILDS` for `esbuild` and `lefthook`.
- Root cause: the recent bump to pnpm 11 (#185) turns ignored dependency build scripts into a hard error, and pnpm 11 no longer reads the `package.json` `pnpm` field — build approvals now live in `pnpm-workspace.yaml`.
- Approve both packages via `pnpm-workspace.yaml` `allowBuilds`, so `esbuild` (binary install) and `lefthook` (git hooks) run their postinstall scripts again.

## Verification

- `pnpm install --frozen-lockfile` (pnpm 11.5.3) now completes; esbuild and lefthook postinstall run with no ignored-builds error.
- Build and full test suite (138 tests) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to enable build execution with esbuild and lefthook integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->