### PR TITLE
fix: resolve #/* subpath imports whose target has a suffix after the wildcard

### DIFF
--- a/.changeset/subpath-import-suffix-jsdoc.md
+++ b/.changeset/subpath-import-suffix-jsdoc.md
@@ -1,0 +1,11 @@
+---
+"zinfer": patch
+---
+
+Preserve JSDoc/TSDoc field descriptions for `#/*` subpath imports whose target
+has a suffix after the wildcard, such as `"#/*": "./src/*.ts"` (the form
+TypeScript requires to map a `#/` subpath import to `.ts` source under
+`moduleResolution: bundler`/`nodenext`). The previous fix only stripped a
+trailing `*`, so a suffix like `.ts` was left in the jiti alias as a literal
+`*`, making the import unresolvable and dropping every description. The wildcard
+and any suffix after it are now stripped, letting jiti resolve the extension.

--- a/src/core/description-extractor.ts
+++ b/src/core/description-extractor.ts
@@ -111,7 +111,10 @@ export class DescriptionExtractor {
           // Wildcard mapping: drop the trailing "*" but keep the "/" so the
           // alias matches "#/..." / "#src/..." without matching "#shared".
           const aliasKey = key.slice(0, -1);
-          let aliasValue = resolve(packageDir, target.replace(/\*$/, ""));
+          // Strip "*" and any suffix after it (e.g. "./src/*.ts" -> "./src/"):
+          // jiti resolves the extension itself, so only the prefix directory
+          // is needed. A bare trailing "*" ("./schemas/*") is handled too.
+          let aliasValue = resolve(packageDir, target.replace(/\*.*$/, ""));
           if (aliasKey.endsWith("/") && !aliasValue.endsWith("/")) {
             aliasValue += "/";
           }

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -320,5 +320,18 @@ describe("ZodTypeExtractor - Generated TypeScript Declarations", () => {
       const nameField = desc?.fields.find((f) => f.path === "name");
       expect(nameField?.description).toBe("The user's name");
     });
+
+    it("should preserve field descriptions when the #/* target has a suffix after the wildcard (#/* -> ./src/*.ts)", async () => {
+      const filePath = resolve(fixturesDir, "subpath-import-suffix/consumer.ts");
+      const descriptionExtractor = new DescriptionExtractor();
+
+      const descriptions = await descriptionExtractor.extractDescriptions(filePath, [
+        "SuffixConsumerSchema",
+      ]);
+
+      const desc = descriptions.get("SuffixConsumerSchema");
+      const nameField = desc?.fields.find((f) => f.path === "name");
+      expect(nameField?.description).toBe("The user's name");
+    });
   });
 });

--- a/tests/fixtures/subpath-import-suffix/consumer.ts
+++ b/tests/fixtures/subpath-import-suffix/consumer.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { SharedSchema } from "#/shared";
+
+export const SuffixConsumerSchema = z.object({
+  shared: SharedSchema,
+  name: z.string().describe("The user's name"),
+});

--- a/tests/fixtures/subpath-import-suffix/package.json
+++ b/tests/fixtures/subpath-import-suffix/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "subpath-import-suffix-fixture",
+  "type": "module",
+  "imports": {
+    "#/*": "./src/*.ts"
+  }
+}

--- a/tests/fixtures/subpath-import-suffix/src/shared.ts
+++ b/tests/fixtures/subpath-import-suffix/src/shared.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const SharedSchema = z.object({
+  id: z.string().describe("Shared identifier"),
+});


### PR DESCRIPTION
## Summary

- Follow-up to the JSDoc subpath-import fix: descriptions were still dropped on Node < 26 for the `"#/*": "./src/*.ts"` mapping form.
- Root cause: `loadSubpathImports` stripped only a *trailing* `*` from the imports target. For `./src/*.ts` the `*` is followed by `.ts`, so it was left in the jiti alias as a literal (`<pkg>/src/*.ts/`). The dynamic import then failed (`Cannot find module .../src/*.ts/shared`) and every description was dropped — while type resolution via ts-morph still worked.
- Fix: strip `*` and any suffix after it so the alias points at the prefix directory; jiti resolves the extension itself. The bare trailing-`*` form (`./schemas/*`) keeps working.

## Why this mapping shape matters

`"./src/*.ts"` (a suffix after `*`) is the form TypeScript requires to map a `#/` subpath import to `.ts` source under `moduleResolution: bundler`/`nodenext`, so it must be supported alongside the `*`-at-end shape.

## Tests

- Added a fixture (`subpath-import-suffix`) with `"#/*": "./src/*.ts"` and a regression test asserting field descriptions survive. Full suite: 139 tests pass.

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preservation of field descriptions when schemas are imported via TypeScript subpath imports with wildcard patterns that include trailing suffixes. In previous versions, descriptions would be unexpectedly dropped for certain import configurations. The issue is now resolved, ensuring all field descriptions are properly maintained across your project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->