### PR TITLE
chore: use version ranges for devDependencies and bump them via renovate

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   parallel: false
   commands:
     oxlint:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx}"
       run: pnpm oxlint --fix {staged_files}
       stage_fixed: true
       priority: 1

--- a/package.json
+++ b/package.json
@@ -50,16 +50,16 @@
     "ts-morph": "^28.0.0"
   },
   "devDependencies": {
-    "@changesets/cli": "2.31.1",
-    "@types/node": "25.9.5",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
-    "knip": "6.31.0",
-    "lefthook": "2.1.10",
-    "oxfmt": "0.61.0",
-    "oxlint": "1.76.0",
-    "typescript": "7.0.2",
-    "vitest": "4.1.10",
-    "zod": "4.4.3"
+    "@changesets/cli": "^2.31.1",
+    "@types/node": "^25.9.5",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "knip": "^6.31.0",
+    "lefthook": "^2.1.10",
+    "oxfmt": "^0.61.0",
+    "oxlint": "^1.76.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,34 +25,34 @@ importers:
         version: 28.0.0
     devDependencies:
       '@changesets/cli':
-        specifier: 2.31.1
+        specifier: ^2.31.1
         version: 2.31.1(@types/node@25.9.5)
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
+        specifier: ^7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       knip:
-        specifier: 6.31.0
+        specifier: ^6.31.0
         version: 6.31.0
       lefthook:
-        specifier: 2.1.10
+        specifier: ^2.1.10
         version: 2.1.10
       oxfmt:
-        specifier: 0.61.0
+        specifier: ^0.61.0
         version: 0.61.0
       oxlint:
-        specifier: 1.76.0
+        specifier: ^1.76.0
         version: 1.76.0
       typescript:
-        specifier: 7.0.2
+        specifier: ^7.0.2
         version: 7.0.2
       vitest:
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(vite@7.3.1(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
 packages:

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchDatasources": ["npm"],
@@ -16,7 +17,8 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "automerge": true,
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "testing",


### PR DESCRIPTION
## Summary

- Switch `devDependencies` from exact pins to caret ranges. `dependencies` and `peerDependencies` were already ranges and are unchanged.
- Set renovate's `rangeStrategy` to `bump`, so it widens a range to cover the new version instead of replacing it with a pin.
- Fix `lefthook.yml`'s `oxlint` pre-commit hook: oxlint has no JSON linter, so giving it JSON-only staged files (as this PR's own commits do) made it exit 1 with "No files found to lint", blocking the commit. Dropped `json`/`jsonc` from its glob to match vinfer's `lefthook.yml`; `oxfmt` already formats JSON separately.
- Refresh `pnpm-lock.yaml` for the new specifiers. Only the `specifier` fields changed; every resolved `version` is byte-identical, so no dependency actually moved.

## Notes

`config:best-practices` pulls in `:pinDevDependencies`, which applies `rangeStrategy: pin` to `devDependencies` through a packageRule. A top-level `rangeStrategy` is outranked by any matching packageRule, so setting it alone would have been silently reverted on the next renovate run. The `devDependencies` rule therefore sets `rangeStrategy: bump` explicitly.

`dependencies` needs no equivalent override: no preset in this config pins regular `dependencies`, so the top-level `rangeStrategy: bump` already applies to it.

No changeset: the published artifact (`dist/`, `bin/`) and `peerDependencies` are untouched, so there is nothing here for consumers to see.

Ported from toiroakr/vinfer#2 (same change, same reasoning).